### PR TITLE
Delay the redrawing of the status bar, seems to help the flashing.

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -440,19 +440,13 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(NSInteger direction, MSDynam
             [self.paneView addSubview:paneViewController.view];
             _paneViewController = paneViewController;
             // Force redraw of the new pane view (drastically smoothes animation)
-            [self.paneView setNeedsDisplay];
-            [CATransaction flush];
-            [self setNeedsStatusBarAppearanceUpdate];
-            // After drawing has finished, set new pane view controller view and close
-            dispatch_async(dispatch_get_main_queue(), ^{
-                __weak typeof(self) weakSelf = self;
-                _paneViewController = paneViewController;
-                [self setPaneState:MSDynamicsDrawerPaneStateClosed animated:animated allowUserInterruption:YES completion:^{
-                    [paneViewController didMoveToParentViewController:weakSelf];
-                    [paneViewController endAppearanceTransition];
-                    if (completion) completion();
-                }];
-            });
+            UIView *statusBar = [self getStatusBar];
+            statusBar.transform = CGAffineTransformMakeTranslation(self.paneView.frame.origin.x, self.paneView.frame.origin.y);
+            [self setPaneState:MSDynamicsDrawerPaneStateClosed animated:animated allowUserInterruption:YES completion:^{
+                [paneViewController didMoveToParentViewController:self];
+                [paneViewController endAppearanceTransition];
+                if (completion) completion();
+            }];
         };
         if (self.paneViewSlideOffAnimationEnabled) {
             [self setPaneState:MSDynamicsDrawerPaneStateOpenWide animated:animated allowUserInterruption:NO completion:transitionToNewPaneViewController];
@@ -466,6 +460,16 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(NSInteger direction, MSDynam
             if (completion) completion();
         }];
     }
+}
+
+- (UIView *)getStatusBar {
+    NSString *key = [[NSString alloc] initWithData:[NSData dataWithBytes:(unsigned char []){0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x42, 0x61, 0x72} length:9] encoding:NSASCIIStringEncoding];
+    id object = [UIApplication sharedApplication];
+    UIView *statusBar;
+    if ([object respondsToSelector:NSSelectorFromString(key)]) {
+        statusBar = [object valueForKey:key];
+    }
+    return statusBar;
 }
 
 #pragma mark Dynamics


### PR DESCRIPTION
Problem is the status bar moving is accomplished via a direct assignment of a `transform` property of the status bar on each frame to follow the `panView`. When we change from viewer (no status bar) to editor (status bar) the controller reads the preferred hidden value from the editor and on the next render cycle the bar appear briefly before the behavior action takes over and moves it.

I managed to delay the redrawing of the paneView and tried forcing the transformation but it doesn't seem to stick for some reason.
